### PR TITLE
Support IPv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,15 @@ of Python (take a look at `Dockerfile` to see which one).
 If you experience weird bugs (especially encoding-related ones)
 while using an older version of Python, please file an issue and
 try to use a newer version of Python.
+
+### can't bind to socket ###
+
+Labello tries to bind itself to `::` by default. This means it will respond to
+all requests regardless of the client's ip address, the used network interface
+or the used version of the internet protocol.
+
+On some systems this might fail. Please file an issue in this case.
+If you get an error message stating something like
+`socket.gaierror: [Errno -9] Address family for hostname not supported`
+on startup, you can try to set `SERVER_ADDRESS` to `0.0.0.0` in the config file.
+This should restore the old behaviour and just listen on IPv4.

--- a/README.md
+++ b/README.md
@@ -15,3 +15,14 @@ python labelprinterServe.py
 ```
 
 or: use Docker  
+
+## POSSIBLE PROBLEMS AND POSSIBLE SOLUTIONS ##
+
+### weird behaviour on old Python versions ###
+
+The main deployment of this software uses a relatively current version
+of Python (take a look at `Dockerfile` to see which one).
+
+If you experience weird bugs (especially encoding-related ones)
+while using an older version of Python, please file an issue and
+try to use a newer version of Python.

--- a/labelprinter.py
+++ b/labelprinter.py
@@ -13,9 +13,9 @@ from brotherprint import BrotherPrint
 class Labelprinter():
     def __init__(self, conf=None, printjob=None):
         if conf:
-            f_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            f_socket.settimeout(conf.PRINTER_TIMEOUT)
-            f_socket.connect((conf.PRINTER_HOST, conf.PRINTER_PORT))
+            f_socket = socket.create_connection(
+                (conf.PRINTER_HOST, conf.PRINTER_PORT), conf.PRINTER_TIMEOUT
+            )
             printjob = BrotherPrint(f_socket)
         assert printjob
         self.printjob = printjob

--- a/labelprinterServeConf.py
+++ b/labelprinterServeConf.py
@@ -2,7 +2,7 @@ import os
 import logging
 
 # HTTP-Server
-SERVER_ADDRESS = '0.0.0.0'
+SERVER_ADDRESS = '::'
 SERVER_PORT = 8000
 SERVER_DEFAULT_TEMPLATE = '/choose'
 

--- a/labelprinterServeConf.py
+++ b/labelprinterServeConf.py
@@ -2,6 +2,7 @@ import os
 import logging
 
 # HTTP-Server
+SERVER_ADDRESS = '0.0.0.0'
 SERVER_PORT = 8000
 SERVER_DEFAULT_TEMPLATE = '/choose'
 

--- a/labelprinterTest.py
+++ b/labelprinterTest.py
@@ -52,8 +52,7 @@ def testQRcode(printjob):
     printjob.char_style('normal')
     printjob.print_page('full')
 
-f_socket = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-f_socket.connect((conf.PRINTER_HOST, conf.PRINTER_PORT))
+f_socket = socket.create_connection((conf.PRINTER_HOST, conf.PRINTER_PORT))
 printjob = BrotherPrint(f_socket)
 
 


### PR DESCRIPTION
This adds support for IPv6 for both the connection to the browser and to the printer while maintaining IPv4 support.
Also, this doesn't need any new external dependencies and still works on Python 2.7
(I haven't tested whether this breaks on Windows or macOS, though.)